### PR TITLE
feat: add hb auth

### DIFF
--- a/packages/cli/src/auth/auth.service.ts
+++ b/packages/cli/src/auth/auth.service.ts
@@ -60,7 +60,13 @@ export class AuthService {
 
 		const bearerToken = req.headers.authorization;
 		if (bearerToken) {
-			req.user = await this.resolveHBJwt(bearerToken);
+			try {
+				req.user = await this.resolveHBJwt(bearerToken);
+			} catch (error) {
+				if (!(error instanceof AuthError)) {
+					throw error;
+				}
+			}
 		}
 
 		if (req.user) next();


### PR DESCRIPTION
## Summary
Support HB auth.
https://honeybook.atlassian.net/browse/CORE-11365

I wanted to use n8n's auth but:
1. It expects the user id in the JWT and we will only have user email
2. It has some validations that we don't want
3. It will check the JWT expiration and re-issue a new token if needed - we don't want that
4. It expects the token in a cookie which is less comfortable for us

Note: to reduce drift to a minimum I'm using n8n's `jwtSecret`: https://github.com/HoneyBook/n8n/blob/master/packages/cli/src/services/jwt.service.ts#L31
It's configurable via an env variable so we can generate it once and put both in HB and in n8n.