### PR TITLE
feat: Publish nodes and credentials command

### DIFF
--- a/packages/cli/src/commands/publishNodesAndCredentials.ts
+++ b/packages/cli/src/commands/publishNodesAndCredentials.ts
@@ -1,0 +1,58 @@
+import { Flags } from '@oclif/core';
+import { ExecutionBaseError } from 'n8n-workflow';
+import { Container } from 'typedi';
+
+import { BaseCommand } from './BaseCommand';
+import { LoadNodesAndCredentials } from '@/LoadNodesAndCredentials';
+import { writeFileSync, rmSync } from 'fs';
+import { execSync } from 'child_process';
+
+export class PublishNodesAndCredentials extends BaseCommand {
+	static description = '\nPublishes the nodes and credentials';
+
+	static flags = {
+		help: Flags.help({ char: 'h' }),
+		path: Flags.string({
+			description: 'S3 path to publish to',
+		}),
+	};
+
+	async init() {
+		await super.init();
+	}
+
+	async run() {
+		const { flags } = await this.parse(PublishNodesAndCredentials);
+
+		console.log('Publishing nodes and credentials...');
+
+		const types = Container.get(LoadNodesAndCredentials).types;
+		console.log(
+			'Loaded',
+			types.credentials.length,
+			'credentials and',
+			types.nodes.length,
+			'nodes.',
+		);
+
+		await this.publish(types.credentials, 'credentials.json', flags.path!);
+		await this.publish(types.nodes, 'nodes.json', flags.path!);
+	}
+
+	/* eslint-disable  @typescript-eslint/no-explicit-any */
+	async publish(data: any, fileName: string, path: string) {
+		writeFileSync(fileName, JSON.stringify(data));
+		const publishCommand = `aws s3 cp ${fileName} ${path}/${fileName} --acl public-read`;
+		execSync(publishCommand);
+		rmSync(fileName);
+	}
+
+	async catch(error: Error) {
+		this.logger.error('Error publishing nodes and credentials. See log messages for details.');
+		this.logger.error('\nExecution error:');
+		this.logger.info('====================================');
+		this.logger.error(error.message);
+		if (error instanceof ExecutionBaseError) this.logger.error(error.description!);
+		this.logger.error(error.stack!);
+	}
+}


### PR DESCRIPTION
## Summary
https://honeybook.atlassian.net/browse/CORE-11458

n8n's frontend fetches nodes.json and credentials.json from n8n's server by fetching http://localhost:5678/types/nodes.json and http://localhost:5678/types/credentials.json.
Those two files are served statically.

I don't want our frontend to go directly to n8n's server (also hard to do due to CORS settings), but I also don't want to proxy this through HPD.

I wrote this command that publishes those files to S3, so our frontend can get it directly through our CDN from:
https://honeybook_cdn.s3.amazonaws.com/automations/nodes.json
https://honeybook_cdn.s3.amazonaws.com/automations/credentials.json

In order to run this script you need to set the same env variables you set when you run n8n:
```bash
export N8N_CONFIG_FILES=/Users/ozweiss/honeybook/n8n/config.dev.json
export N8N_CUSTOM_EXTENSIONS=/Users/ozweiss/honeybook/n8n/packages/n8n-nodes-honeybook/dist
n8n publishNodesAndCredentials --path  s3://honeybook_cdn/automations
```